### PR TITLE
I'd like to contribute this fix to the InCNTRE repo. At least one of the testmodules InCNTRE has added trip on the bug we found. The proposed change prevents any module from causing the --list command to abort.

### DIFF
--- a/oft
+++ b/oft
@@ -460,8 +460,11 @@ if config["list"]:
     print "\nTest List:"
     for (modname, (mod, tests)) in test_modules.items():
         mod_count += 1
-        desc = mod.__doc__.strip()
-        desc = desc.split('\n')[0]
+        try:
+            desc = mod.__doc__.strip()
+            desc = desc.split('\n')[0]
+        except:
+            desc = "No description"
         start_str = "  Module " + mod.__name__ + ": "
         print start_str + _space_to(22, start_str) + desc
         for (testname, test) in tests.items():


### PR DESCRIPTION
list code would abort. Added a try block to handle cases where
modules have been added but lack descriptions. This makes the
oft code bulletproof from external modules in this particular way.
