### PR TITLE
Updating group 80, test cases 60 and 70 to reflect test specification

### DIFF
--- a/tests/testgroup80.py
+++ b/tests/testgroup80.py
@@ -215,8 +215,8 @@ class Grp80No60(base_tests.SimpleProtocol):
                              "Did not receive response to features_request.")
         logging.info("Verifying response's essential fields.")
         self.assertEqual(res.header.type, ofp.OFPT_FEATURES_REPLY,
-                         "Response type was %d, but expected %d.",
-                         res.header.type, ofp.OFPT_FEATURES_REPLY)
+                         "Response type was %d, but expected %d." %
+                         (res.header.type, ofp.OFPT_FEATURES_REPLY))
         self.assertEqual(res.header.xid,req.header.xid,
                          ("Transaction ID of response did not match the "
                           "transaction ID of the request."))


### PR DESCRIPTION
It looks like 80.60 and 80.70 may have gotten switched around a little.

I've changed 80.60 to be much simpler. It now verifies simply that the features_request / reply dialogue works.

The code that was previously in 80.60 did a lot of features_reply verification. I've moved that code into 80.70 which requires verification of fields inside the feature_reply message.
