### PR TITLE
40.190 - Test case rewrite

### DIFF
--- a/tests/testgroup40.py
+++ b/tests/testgroup40.py
@@ -809,7 +809,7 @@ class Grp40No190(base_tests.SimpleDataPlane):
     @wireshark_capture
     def runTest(self):
         logging = get_logger()
-        logging.info("Running Grp40No190b: Delete with constraint out_port")
+        logging.info("Running Grp40No190: Delete with constraint out_port")
 
         ports = config["port_map"].keys()
         ports.sort()


### PR DESCRIPTION
The previous version used a test method which relied on the flow count reported by an `aggregate_stats_reply` message. On occasion this forced us to use manual verification, as some devices report the sum of the regular and emergency flow tables.

This new method removes the previous restriction, through data plane verification. It also aligns more closely to the openflow v1.0 test specification.
