### PR TITLE
Fix typos that mistake of_ports as of_port.

### DIFF
--- a/tests/testgroup20.py
+++ b/tests/testgroup20.py
@@ -184,15 +184,15 @@ class Grp20No50(base_tests.SimpleDataPlane):
         logging.info("Inserting a flow entry")
         
 
-        # Insert a flow matching on ingress_port with action A (output to of_port[1])    
+        # Insert a flow matching on ingress_port with action A (output to of_ports[1])
         (pkt,match) = wildcard_all_except_ingress(self,of_ports)
   
-        # Modify the flow action (output to of_port[2])
+        # Modify the flow action (output to of_ports[2])
         logging.info("Modifying the output action of the flow entry")
         modify_flow_action(self,of_ports,match)
         
         logging.info("Expecting the Test Packet to implement the modified action")
-        # Send the Test Packet and verify action implemented is A' (output to of_port[2])
+        # Send the Test Packet and verify action implemented is A' (output to of_ports[2])
         send_packet(self,pkt,of_ports[0],of_ports[2])
         logging.info("Modified Action implemented")               
 

--- a/tests/testgroup30.py
+++ b/tests/testgroup30.py
@@ -320,7 +320,7 @@ class Grp30No90(base_tests.SimpleDataPlane):
         	yes_ports=[]
         	no_ports = set(of_ports)
         	receive_pkt_check(self.dataplane,pkt,yes_ports,no_ports,self)
-		logging.info("The switch successfully drops packets on port " +str(of_port[1]))
+		logging.info("The switch successfully drops packets on port " +str(of_ports[1]))
 		
 
 	except:

--- a/tests/testgroup40.py
+++ b/tests/testgroup40.py
@@ -454,7 +454,7 @@ class Grp40No90(base_tests.SimpleDataPlane):
 
         logging.info("Installing a flow")
            
-        #Create and add flow-1 Match on all, except one wildcarded (src adddress).Action A , output to of_port[1]
+        #Create and add flow-1 Match on all, except one wildcarded (src adddress).Action A , output to of_ports[1]
         #(pkt,match) = match_all_except_source_address(self,of_ports)
         (pkt,match) = exact_match(self,of_ports)
 
@@ -879,7 +879,7 @@ class Grp40No200(base_tests.SimpleDataPlane):
         logging.info("Adding and modifying flow with out_port fields set")
         logging.info("Expecting switch to ignore out_port")
 
-        # Create and add flow-1,Action A ,output to port of_port[1], out_port set to of_ports[2]
+        # Create and add flow-1,Action A ,output to port of_ports[1], out_port set to of_ports[2]
         (pkt,match) = wildcard_all_except_ingress(self,of_ports)
 
         # Verify flow is active


### PR DESCRIPTION
The typos cause Grp30No100 case failed to pass even the switch under test behaves correctly.
This patchset fixed the typos present in code and comments.