### PR TITLE
implementation of Grp70No240: Ordering not possible

### DIFF
--- a/tests/testgroup70.py
+++ b/tests/testgroup70.py
@@ -1013,6 +1013,10 @@ class Grp70No240(base_tests.SimpleProtocol):
         logging = get_logger()
         logging.info("Running FlowModFailed Ordering not possible Grp70No240 test")
 
+        rc = delete_all_flows(self.controller)
+        self.assertTrue(rc != -1, "Error installing flow mod")
+        self.assertEqual(do_barrier(self.controller), 0, "Barrier failed")
+
         msg = message.flow_mod()
         act1 = action.action_output()
         act2 = action.action_set_tp_src()
@@ -1026,7 +1030,7 @@ class Grp70No240(base_tests.SimpleProtocol):
 
         rv=self.controller.message_send(packed)
         self.assertTrue(rv==0,"Unable to send the message")
-
+        self.assertEqual(do_barrier(self.controller), 0, "Barrier failed")
 
         (response, raw) = self.controller.poll(ofp.OFPT_ERROR, timeout=10)
         self.assertTrue(response is not None,"Did not receive an error")

--- a/tests/testgroup70.py
+++ b/tests/testgroup70.py
@@ -1022,6 +1022,7 @@ class Grp70No240(base_tests.SimpleProtocol):
         self.assertEqual(do_barrier(self.controller), 0, "Barrier failed")
 
         msg = message.flow_mod()
+        msg.command = ofp.OFPFC_ADD
         act1 = action.action_output()
         act2 = action.action_set_tp_src()
         act1.port = of_ports[0]

--- a/tests/testgroup70.py
+++ b/tests/testgroup70.py
@@ -1038,6 +1038,6 @@ class Grp70No240(base_tests.SimpleProtocol):
 
         (response, raw) = self.controller.poll(ofp.OFPT_ERROR, timeout=10)
         self.assertTrue(response is not None,"Did not receive an error")
-        self.assertTrue(response.type==ofp.OFPET_FLOW_MOD_FAILED,"Unexpected Error type. Expected OFPET_FLOW_MOD_FAILED error type")
-        self.assertTrue(response.code==ofp.OFPFMFC_UNSUPPORTED," Unexpected error code, Expected ofp.OFPFMFC_UNSUPPORTED or ofp.OFPFMFC_EPERM error code got{0}" .format(response.code))
+        self.assertTrue(response.type==ofp.OFPET_FLOW_MOD_FAILED,"Unexpected Error type. Expected OFPET_FLOW_MOD_FAILED error type got {0}".format(response.type))
+        self.assertTrue(response.code==ofp.OFPFMFC_UNSUPPORTED," Unexpected error code, Expected ofp.OFPFMFC_UNSUPPORTED error code got {0}" .format(response.code))
 

--- a/tests/testgroup70.py
+++ b/tests/testgroup70.py
@@ -1013,6 +1013,10 @@ class Grp70No240(base_tests.SimpleProtocol):
         logging = get_logger()
         logging.info("Running FlowModFailed Ordering not possible Grp70No240 test")
 
+        of_ports = config["port_map"].keys()
+        of_ports.sort()
+        self.assertTrue(len(of_ports) > 1, "Not enough ports for test")
+
         rc = delete_all_flows(self.controller)
         self.assertTrue(rc != -1, "Error installing flow mod")
         self.assertEqual(do_barrier(self.controller), 0, "Barrier failed")
@@ -1020,7 +1024,7 @@ class Grp70No240(base_tests.SimpleProtocol):
         msg = message.flow_mod()
         act1 = action.action_output()
         act2 = action.action_set_tp_src()
-        act1.port = 99
+        act1.port = of_ports[0]
         act2.tp_port = 8080
         
         self.assertTrue(msg.actions.add(act1), "Could not add action")

--- a/tests/testgroup70.py
+++ b/tests/testgroup70.py
@@ -1009,7 +1009,6 @@ class Grp70No240(base_tests.SimpleProtocol):
     If a switch cannot process the action list for any  flow mod message in the order specied,
     it must return an Error with error.type OFPET_FLOW_MOD_FAILED and error.code OFPFMFC_UNSUPPORTED or ofp.OFPFMFC_EPERM and reject the flow """
 
-    @wireshark_capture
     def runTest(self):
         logging = get_logger()
         logging.info("Running FlowModFailed Ordering not possible Grp70No240 test")

--- a/tests/testgroup70.py
+++ b/tests/testgroup70.py
@@ -1007,7 +1007,7 @@ class Grp70No240(base_tests.SimpleProtocol):
     """
     Ordering not possible - cannot process in order specified
     If a switch cannot process the action list for any  flow mod message in the order specied,
-    it must return an Error with error.type OFPET_FLOW_MOD_FAILED and error.code OFPFMFC_UNSUPPORTED or ofp.OFPFMFC_EPERM and reject the flow """
+    it must return an Error with error.type OFPET_FLOW_MOD_FAILED and error.code OFPFMFC_UNSUPPORTED and reject the flow """
 
     def runTest(self):
         logging = get_logger()

--- a/tests/testgroup70.py
+++ b/tests/testgroup70.py
@@ -1039,5 +1039,5 @@ class Grp70No240(base_tests.SimpleProtocol):
         (response, raw) = self.controller.poll(ofp.OFPT_ERROR, timeout=10)
         self.assertTrue(response is not None,"Did not receive an error")
         self.assertTrue(response.type==ofp.OFPET_FLOW_MOD_FAILED,"Unexpected Error type. Expected OFPET_FLOW_MOD_FAILED error type")
-        self.assertTrue(response.code==ofp.OFPFMFC_UNSUPPORTED or response.code==ofp.OFPFMFC_EPERM," Unexpected error code, Expected ofp.OFPFMFC_UNSUPPORTED or ofp.OFPFMFC_EPERM error code got{0}" .format(response.code))
+        self.assertTrue(response.code==ofp.OFPFMFC_UNSUPPORTED," Unexpected error code, Expected ofp.OFPFMFC_UNSUPPORTED or ofp.OFPFMFC_EPERM error code got{0}" .format(response.code))
 


### PR DESCRIPTION
This test case is almost identical with 100.250, which uses OFPAT_SET_TP_SRC instand of OFPAT_SET_DL_SRC. So I write this case based on testgroup100.Grp100No250.