### PR TITLE
Updates wireshark captures to include traffic passed during setUp method

### DIFF
--- a/oft
+++ b/oft
@@ -492,9 +492,6 @@ if not config["port_map"]:
 logging.debug("Configuration: " + str(config))
 logging.info("OF port map: " + str(config["port_map"]))
 
-# Load config for publishing logs
-oflog.set_config()
-
 # Build tests
 test_modules = prune_tests(config["test_spec"], load_test_modules(config))
 

--- a/src/python/oftest/base_tests.py
+++ b/src/python/oftest/base_tests.py
@@ -12,6 +12,7 @@ from oftest import config
 import oftest.controller as controller
 import oftest.cstruct as ofp
 import oftest.message as message
+import oftest.oflog as oflog
 import oftest.dataplane as dataplane
 import oftest.action as action
 import oftest.testutils
@@ -25,6 +26,7 @@ class SimpleProtocol(unittest.TestCase):
     mandatory = False
 
     def setUp(self):
+        oflog.start_logging(self)
         logging.info("** START TEST CASE " + str(self))
         self.controller = controller.Controller(
             host=config["controller_host"],
@@ -130,6 +132,7 @@ class DataPlaneOnly(unittest.TestCase):
     """
 
     def setUp(self):
+        oflog.start_logging(self)
         self.clean_shutdown = True
         logging.info("** START DataPlaneOnly CASE " + str(self))
         self.dataplane = dataplane.DataPlane(config)

--- a/src/python/oftest/oflog.py
+++ b/src/python/oftest/oflog.py
@@ -65,7 +65,55 @@ def create_log_directory(dirName):
     finally:
         os.makedirs(logDir)
 
+
+def create_log_directory2(log_directory):
+    """Deletes directory, (if already exists) and then recreates
+    directory.
+    """
+    try:
+        Popen(["rm", "-rf", log_directory],stdout=None)
+        time.sleep(1)
+    except:
+        pass
+    finally:
+        os.makedirs(log_directory)
+
+def start_wireshark_cap(log_directory):
+    process_ids = []
+    interfaces = config["port_map"].values()
+    interfaces.append(find_iface(config["controller_host"]))
+
+    for iface in interfaces:
+        fd = log_directory + "{0}.pcap".format(iface)
+        pid = Popen(["tshark", "-i", str(iface), "-w", fd, "-q"],
+                    stdout=DEVNULL, stderr=DEVNULL)
+        process_ids.append(pid)
+    time.sleep(1)
+    return process_ids
+
+def stop_wireshark_cap(process_ids):
+    for pid in process_ids:
+        pid.terminate()
+    time.sleep(1)
+
+def start_logging(testcase):
+    """Start wireshark captures for each network interface."""
+    if not config["publish"]: return
+
+    _group, _test = testcase.__class__.__name__[3:].split("No")
+    directory = "./src/python/ofreport/logs/Grp{0}No{1}/"
+    log_directory = directory.format(_group, _test)
+    create_log_directory2(log_directory)
+
+    process_ids = start_wireshark_cap(log_directory)
+    testcase.addCleanup(stop_logging, process_ids)
+
+def stop_logging(process_ids):
+    stop_wireshark_cap(process_ids)
+
 def get_logger():
+    """Configure logging for each test case.
+    """
     if not config["publish"]:
         return logging
     LOG = logging.getLogger(pubName)

--- a/src/python/oftest/oflog.py
+++ b/src/python/oftest/oflog.py
@@ -109,6 +109,8 @@ def start_logging(testcase):
     testcase.addCleanup(stop_logging, process_ids)
 
 def stop_logging(process_ids):
+    """Stop wireshark captures for each network interface."""
+    if not config["publish"]: return
     stop_wireshark_cap(process_ids)
 
 def get_logger():

--- a/src/python/oftest/oflog.py
+++ b/src/python/oftest/oflog.py
@@ -5,7 +5,12 @@ import logging
 import os
 import time
 from oftest import config
- 
+
+try:
+    from subprocess import DEVNULL
+except ImportError:
+    DEVNULL = open(os.devnull, "wb")
+
 """
 oflog.py
 Provides Loggers for oftest cases, and easy to use wireshark
@@ -14,59 +19,14 @@ logging.
 Test case writers use three main functions.
 1. get_logger() - Returns a Logger for each testcase or the
 default logger if --publish is not passed.
-2. @wireshark_capture - Decorator Uses tshark to capture network
-traffic while function is being run.
- 
-oflog is configured using one method.
-1. set_config() - Records all logs under directory. directory
-*must* end in '/'. Also configures wireshark to log the interface
-associated with ctrlAddr and all other data plane interfaces.
+2. start_logging(testcase) - Starts tshark on each test interface,
+and the controller interface if -H is passed on the CLI. Additionally
+registers tshark pids to testcase for process clean up.
 """
  
 pubName = ""
-wiresharkMap = {}
-DEVNULL = None
 
-def wireshark_capture(f):
-    """
-    Decorator to wrap Testcases. Gives
-    a one second buffer for wireshark to
-    start and stop if publishing is enabled.
-    """
-    def pub(*args, **kargs):
-        create_log_directory(str(args[0].__class__.__name__))
-        start_wireshark()
-        time.sleep(3)
-        try:
-            f(*args, **kargs)
-        finally:
-            stop_wireshark()
-            time.sleep(3)
-
-    if not config["publish"]:
-        return f
-    else:
-        return pub
-
-def create_log_directory(dirName):
-    """
-    Creates a directory named dirName. Also save dirName as a
-    global variable to inform get_logger() where to log to.
-    """
-    global pubName
-    pubName = dirName
-    logDir = "%slogs/%s" % ("./src/python/ofreport/", pubName)
-    print logDir
-    try:
-        Popen(["rm", "-rf", logDir],stdout=None)
-        time.sleep(1)
-    except:
-        pass
-    finally:
-        os.makedirs(logDir)
-
-
-def create_log_directory2(log_directory):
+def create_log_directory(log_directory):
     """Deletes directory, (if already exists) and then recreates
     directory.
     """
@@ -81,7 +41,7 @@ def create_log_directory2(log_directory):
 def start_wireshark_cap(log_directory):
     process_ids = []
     interfaces = config["port_map"].values()
-    interfaces.append(find_iface(config["controller_host"]))
+    interfaces.append(find_interface(config["controller_host"]))
 
     for iface in interfaces:
         fd = log_directory + "{0}.pcap".format(iface)
@@ -101,9 +61,11 @@ def start_logging(testcase):
     if not config["publish"]: return
 
     _group, _test = testcase.__class__.__name__[3:].split("No")
+    global pubName
+    pubName = "Grp{0}No{1}".format(_group, _test)
     directory = "./src/python/ofreport/logs/Grp{0}No{1}/"
     log_directory = directory.format(_group, _test)
-    create_log_directory2(log_directory)
+    create_log_directory(log_directory)
 
     process_ids = start_wireshark_cap(log_directory)
     testcase.addCleanup(stop_logging, process_ids)
@@ -119,7 +81,7 @@ def get_logger():
     if not config["publish"]:
         return logging
     LOG = logging.getLogger(pubName)
-    LOG.setLevel(config["dbg_level"])
+    LOG.setLevel(logging.DEBUG)
     logDir = "%slogs/%s" % ("./src/python/ofreport/", pubName)
     h = logging.FileHandler(logDir+"/testcase.log")
     h.setLevel(logging.DEBUG)
@@ -128,32 +90,8 @@ def get_logger():
     h.setFormatter(f)
     LOG.addHandler(h)
     return LOG
- 
-def start_wireshark():
-    for iface in wiresharkMap:
-        fd = "%slogs/%s/%s.pcap" % ("./src/python/ofreport/", pubName, wiresharkMap[iface][1])
-        wiresharkMap[iface][0] = Popen(["tshark", "-i", str(iface), "-w", fd, "-q"], stdout=DEVNULL, stderr=DEVNULL)
 
-def stop_wireshark():
-    for iface in wiresharkMap:
-        wiresharkMap[iface][0].terminate()
-
-def set_config():
-    if not config["publish"]:
-        return
-    global wiresharkMap
-    global DEVNULL
-    DEVNULL = open(os.devnull, 'w')
-
-    for k in config["port_map"]:
-        iface = config["port_map"][k]
-        # [pid, "dataX"]
-        wiresharkMap[iface] = [None, "data"+str(k)]
-    # Controller's iface is not included in a config. Look it up.
-    iface = find_iface(config["controller_host"])
-    wiresharkMap[iface] = [None, "ctrl"]
-
-def find_iface(ip="127.0.0.1"):
+def find_interface(ip="127.0.0.1"):
     """
     Parses ifconfig to return the interface associated with ip.
     """

--- a/tests/testgroup10.py
+++ b/tests/testgroup10.py
@@ -1,10 +1,10 @@
 """
 These tests fall under Conformance Test-Suite (OF-SWITCH-1.0.0 TestCases).
 Refer Documentation -- Detailed testing methodology 
-    <Some of test-cases are directly taken from oftest> """
+<Some of test-cases are directly taken from oftest>
 
 "Test Suite 1 --> Basic Sanity Tests"
-
+"""
 
 import time
 import sys
@@ -27,16 +27,15 @@ from oftest.testutils import *
 from time import sleep
 from FuncUtils import *
 
+
 class Grp10No10(base_tests.SimpleDataPlane):
     """
     Switch Startup behaviour without estabilished control channel. 
     Make sure no dataplane packets are forwarded (since there are no flows)
     i.e switch does not behave like a learning switch
     """
-
-    @wireshark_capture
+    
     def runTest(self):
-        
         logging = get_logger()
         logging.info("Running TestNo10 SwStartup test")
 
@@ -55,40 +54,33 @@ class Grp10No10(base_tests.SimpleDataPlane):
         self.controller.shutdown()
         
         # Keep sending the packets till the control plane gets shutdown
-
         pkt = simple_tcp_packet()
         
         assertionerr = False
         logging.info("Checking for Control channel connection status")
 
-        try :
+        try:
             for x in range(15):
         	self.dataplane.send(ingress_port, str(pkt))
                 (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN, timeout=5)
                 self.assertTrue(response is not None,
                                 'PacketIn is not generated--Control plane is down')
         
-        except AssertionError :
-        
+        except AssertionError:
             #Send a simple tcp packet on ingress_port
             logging.info("Control  Channel Connection not present")
             logging.info("Sending simple tcp packet ...")
             self.dataplane.send(ingress_port, str(pkt))
         
-
             #Verify dataplane packet should not be forwarded
             logging.info("Packet should not be forwarded to any dataplane port")
             no_ports=set(of_ports)
             yes_ports=[]
             receive_pkt_check(self.dataplane,pkt,yes_ports,no_ports,self)
             assertionerr = True
-        
-        else :
-
+        else:
             self.assertTrue(assertionerr is True, "Failed to shutdown the control plane")
-            
-      
-	
+
 
 class Grp10No20(base_tests.SimpleProtocol):
     """
@@ -99,7 +91,6 @@ class Grp10No20(base_tests.SimpleProtocol):
     Note : If tcp port is other than 6633, make sure sw is also configured to listen on the alternate port
     """
     
-    @wireshark_capture
     def runTest(self):
         # Send echo_request to verify connection
         logging = get_logger()
@@ -122,11 +113,9 @@ class Grp10No30(base_tests.SimpleDataPlane):
     
     @of_version can be passed from command line , default is 0x01
     """
-    
 
     def setUp(self):
-        
-        #This is almost same as setUp in SimpleProtocol except that intial hello is set to false
+        # This is almost same as setUp in SimpleProtocol except that intial hello is set to false
         start_logging(self)
         self.controller = controller.Controller(
             host=config["controller_host"],
@@ -165,11 +154,12 @@ class Grp10No40(base_tests.SimpleProtocol):
     """
     Verify switch negotiates on the correct version.
     Upon receipt of the Hello message, the recipient may calculate the OpenFlow protocol version
-    to be used as the smaller of the version number that it sent and the one that it received. 
-
+    to be used as the smaller of the version number that it sent and the one that it received.
     """
+
     def setUp(self):
-        #This is almost same as setUp in SimpleProtcocol except that intial hello is set to false
+        # This is almost same as setUp in SimpleProtcocol except that intial hello is set to false
+        start_logging(self)
         self.controller = controller.Controller(
             host=config["controller_host"],
             port=config["controller_port"])
@@ -191,7 +181,7 @@ class Grp10No40(base_tests.SimpleProtocol):
             raise Exception("Controller startup failed (no switch addr)")
         logging.info("Connected " + str(self.controller.switch_addr))
         
-    @wireshark_capture 
+     
     def runTest(self):
         logging = get_logger()
 
@@ -216,8 +206,10 @@ class Grp10No50(base_tests.SimpleProtocol):
     Verify the switch reports correct error message and terminates the connection, 
     if no common version can be negotiated
     """
+
     def setUp(self):
-        #This is almost same as setUp in SimpleProtcocol except that intial hello is set to false
+        # This is almost same as setUp in SimpleProtcocol except that intial hello is set to false
+        start_logging(self)
         self.controller = controller.Controller(
             host=config["controller_host"],
         # clean_shutdown should be set to False to force quit app
@@ -240,7 +232,7 @@ class Grp10No50(base_tests.SimpleProtocol):
             raise Exception("Controller startup failed (no switch addr)")
         #logging.info("Connected " + str(self.controller.switch_addr))
         
-    @wireshark_capture    
+        
     def runTest(self):
         logging = get_logger()
 
@@ -274,10 +266,11 @@ class Grp10No50(base_tests.SimpleProtocol):
 class Grp10No80(base_tests.SimpleProtocol):
     """
     Verify Echo timeout causes connection to the controller to drop
-    """ 
-    def setUp(self):
+    """
 
-        #This is almost same as setUp in SimpleProtcocol except that Echo response is set to false
+    def setUp(self):
+        # This is almost same as setUp in SimpleProtcocol except that Echo response is set to false
+        start_logging(self)
         self.controller = controller.Controller(
             host=config["controller_host"],
             port=config["controller_port"])
@@ -304,7 +297,7 @@ class Grp10No80(base_tests.SimpleProtocol):
         self.controller.shutdown()
         if self.clean_shutdown:
             self.controller.join()    
-    @wireshark_capture    
+        
     def runTest(self):
         logging = get_logger()
         logging.info("Running TestNo80 EchoTimeout ")
@@ -329,7 +322,7 @@ class Grp10No110(base_tests.SimpleDataPlane):
     Testcase unstable framework issues.
     """
    
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
 
@@ -448,7 +441,7 @@ class Grp10No100(base_tests.SimpleDataPlane):
     then verify 
     1. Emergency mode removes standard flow entries after the control channel disconnection
     """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         (response, pkt)=self.controller.poll(ofp.OFPT_HELLO, timeout=15)
@@ -521,7 +514,7 @@ class Grp10No90(base_tests.SimpleDataPlane):
     then verify 
     1. Emergency flows can be added , they are active after control channel gets disconnected 
     """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
 
@@ -596,7 +589,7 @@ class Grp10No120(base_tests.SimpleDataPlane):
     """If switch does not support Emergency mode , it should support fail-secure mode
     (refer spec 1.0.1).
     Verify even after the control channel disconnection, the standard flows timeout normally"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
 

--- a/tests/testgroup10.py
+++ b/tests/testgroup10.py
@@ -127,6 +127,7 @@ class Grp10No30(base_tests.SimpleDataPlane):
     def setUp(self):
         
         #This is almost same as setUp in SimpleProtocol except that intial hello is set to false
+        start_logging(self)
         self.controller = controller.Controller(
             host=config["controller_host"],
             port=config["controller_port"])
@@ -145,7 +146,6 @@ class Grp10No30(base_tests.SimpleDataPlane):
             raise Exception("Controller startup failed (no switch addr)")
         logging.info("Connected " + str(self.controller.switch_addr))
 
-    @wireshark_capture
     def runTest(self):
         logging = get_logger()
         logging.info("Running Test Grp10No30 Version Announcement test")

--- a/tests/testgroup100.py
+++ b/tests/testgroup100.py
@@ -33,7 +33,7 @@ class Grp100No10(base_tests.SimpleProtocol):
     it generates an OFPT_ERROR msg with Type Field OFPET_HELLO_FAILED
     code field OFPHFC_INCOMPATIBLE    
     """
-    @wireshark_capture
+    
     def setUp(self):
         logging = get_logger()
         #This is almost same as setUp in SimpleProtocol except that intial hello is set to false
@@ -84,7 +84,7 @@ class Grp100No30(base_tests.SimpleProtocol):
     it generates OFPT_ERROR_msg with Type field OFPET_BAD_REQUEST 
     and code field OFPBRC_BAD_VERSION
     """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp100No20 BadRequestBadVersion Test") 
@@ -111,7 +111,7 @@ class Grp100No40(base_tests.SimpleProtocol):
    supported by the switch ,it generates an OFPT_ERROR msg with the Type Field OFPET_BAD_REQUEST
    and code field OFPBRC_BAD_TYPE
     """ 
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp100No30 BadRequestBadType test")
@@ -137,7 +137,7 @@ class Grp100No50(base_tests.SimpleProtocol):
     message with a OFPBRC_BAD_VENDOR error code and OFPET_BAD_REQUEST error
     type.
     """
-    @wireshark_capture
+    
     def runTest(self):  
         logging = get_logger()
         logging.info("Running Grp100No50 BadRequestBadVendor test")      
@@ -156,7 +156,7 @@ class Grp100No80(base_tests.SimpleProtocol):
     switch generates an OFPT_ERROR msg with type field OFPET BAD_REQUEST 
     and code field OFPBRC_BAD_LEN
     """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp100No80 BadRequestBadLength test")
@@ -191,7 +191,7 @@ class Grp100No90(base_tests.SimpleDataPlane):
     replies back with OFPT_ERROR msg with type fiels OFPET_BAD_REQUEST
 
     """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp100No90 BadRequestBufferUnknown test")
@@ -280,7 +280,7 @@ class Grp100No100(base_tests.SimpleProtocol):
     replies back with OFPT_ERROR msg with type fiels OFPET_BAD_REQUEST
 
     """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp100No100 BadRequestBufferUnknown test")
@@ -315,7 +315,7 @@ class Grp100No110(base_tests.SimpleDataPlane):
     """When the type field in the action header specified by the controller is unknown , 
     the switch generates an OFPT_ERROR msg with type field OFPBET_BAD_ACTION and code field OFPBAC_BAD_TYPE
     """
-    @wireshark_capture
+    
     def runTest(self):  
         logging = get_logger()
         logging.info("Running Grp100No110 test")
@@ -347,7 +347,7 @@ class Grp100No120(base_tests.SimpleDataPlane):
     """When the length field in the action header specified by the controller is wrong ,
     the switch replies back with an OFPT_ERROR msg with Type Field OFPBAC_BAD_LEN"""
     
-    @wireshark_capture
+    
     def runTest(self):  
         logging = get_logger()
         logging.info("Running Grp100No120 BadActionBadLen test")
@@ -386,7 +386,7 @@ class Grp100No150(base_tests.SimpleProtocol):
     Some switches may generate an OFPT_ERROR , with error type  FLOW_MOD_FAILED and error code OFPFMFC_EPERM
     (this is also acceptable)
     """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp100No150 BadActionBadPort test")
@@ -426,7 +426,7 @@ class Grp100No160(base_tests.SimpleProtocol):
 
     Error code OFPBAC_EPERM error is also acceptable
     """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp100No160 BadActionBadArgument test")
@@ -468,7 +468,7 @@ class Grp100No180(base_tests.SimpleProtocol):
     with type field OFPT_BAD_ACTION and code field OFPBAC_TOO_MANY
     """
 
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running BadActionTooMany Grp100No180 test")
@@ -516,7 +516,7 @@ class Grp100No190(base_tests.SimpleDataPlane):
     If the switch is not able to process the Enqueue action specified by the controller then 
     the switch should generate an OFPT_ERROR msg ,type field OFPT_BAD_ACTION and code field OFPBAC_BAD_QUEUE"""
    
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running BadActionQueue Grp100No190 test")
@@ -564,7 +564,7 @@ class Grp100No210(base_tests.SimpleDataPlane):
         overlapping flow is inserted then an error 
         type OFPET_FLOW_MOD_FAILED code OFPFMFC_OVERLAP"""
     
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running FlowModFailedOverlap Grp100No210 test")
@@ -625,7 +625,7 @@ class Grp100No230(base_tests.SimpleProtocol):
         Otherwise , should switch should respond with an OFPT ERROR msg , 
         type field OFPET_FLOW_MOD_FAILED, code field OFPFMFC_BAD_EMERG_TIMEOUT"""
 
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running FlowModFailedBadEmer Grp100No230 test")
@@ -676,7 +676,7 @@ class Grp100No240(base_tests.SimpleProtocol):
     some invalid command , the switch responds with an OFPT_ERROR msg , 
     type field OFPET_FLOW_MOD_FAILED and code field OFPFMFC_BAD_COMMAND """
     
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running FlowModFailedBadCommand Grp100No240 test")
@@ -704,7 +704,7 @@ class Grp100No250(base_tests.SimpleProtocol):
     If a switch cannot process the action list for any  flow mod message in the order specied, 
     it must return an Error with error.type OFPET_FLOW_MOD_FAILED and error.code OFPFMFC_UNSUPPORTED or OFPFMFC_EPERM error and reject the flow """
     
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running FlowModFailed Unsupported action list Grp100No250 test")
@@ -737,7 +737,7 @@ class Grp100No260(base_tests.SimpleProtocol):
     error message is received.
     """
 
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running PortModFailedBadPort Grp100No260 test")
@@ -761,7 +761,7 @@ class Grp100No270(base_tests.SimpleProtocol):
     from one returned in ofp_phy_port struct.,the switch will respond back with an OFPT_ERROR msg , 
     type field OFPET_PORT_MOD_FAILED and code field OFPPMFC_BAD_HW_ADDR
     """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running PortModFailedBadHwAdd Grp100No270 test")
@@ -803,7 +803,7 @@ class Grp100No280(base_tests.SimpleDataPlane):
      is an invalid port , then the switch responds back with an error msg OFPT_ERROR msg , 
      type field OFPET_QUEUE_OP_FAILED , code field OFPQOFC_BAD_PORT"""
     
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp100No280 QueueOpFailedBadPort test")
@@ -835,7 +835,7 @@ class Grp100No290(base_tests.SimpleDataPlane):
     is an invalid queue ,then the switch responds back with an error msg OFPT_ERROR msg , 
     type field OFPET_QUEUE_OP_FAILED , code field OFPQOFC_BAD_QUEUE"""
     
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running QueueOpFailedBadQueue Grp100No290 test")

--- a/tests/testgroup100.py
+++ b/tests/testgroup100.py
@@ -35,6 +35,7 @@ class Grp100No10(base_tests.SimpleProtocol):
     """
     
     def setUp(self):
+        start_logging(self)
         logging = get_logger()
         #This is almost same as setUp in SimpleProtocol except that intial hello is set to false
         self.controller = controller.Controller(

--- a/tests/testgroup20.py
+++ b/tests/testgroup20.py
@@ -30,7 +30,7 @@ class Grp20No10(base_tests.SimpleProtocol):
     a) Send OFPT_FEATURES_REQUEST
 	b) Verify OFPT_FEATURES_REPLY is received"""
     
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp20No10 Features_Request test")
@@ -63,7 +63,7 @@ class Grp20No20(base_tests.SimpleProtocol):
     a) Send OFPT_GET_CONFIG_REQUEST
     b) Verify OFPT_GET_CONFIG_REPLY is received"""
     
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp20No20 Configuration_Request test ")
@@ -94,7 +94,7 @@ class Grp20No30(base_tests.SimpleProtocol):
     a) Send  OFPT_FLOW_MOD , command = OFPFC_ADD 
     c) Send ofp_aggregate_stats_request , verify flows=1 in reply"""
     
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp20No30 Modify_State_Add test")
@@ -128,7 +128,7 @@ class Grp20No40(base_tests.SimpleProtocol):
     c) Send OFPT_FLOW_MOD, command = OFPFC_DELETE
     c) Send ofp_table_stats request , verify active_count=0 in reply"""
     
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp20No40 Modify_State_Delete test")
@@ -169,7 +169,7 @@ class Grp20No50(base_tests.SimpleDataPlane):
     b) Send OFPT_FLOW_MOD, command = OFPFC_MODIFY , with output action A'
     c) Send a packet matching the flow, verify packet implements action A' """
     
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp20No50 Modify_State_Modify test")
@@ -203,7 +203,7 @@ class Grp20No60(base_tests.SimpleProtocol):
     b) Send ofp_flow_stats request
     b) Verify switch replies with a ofp_flow_stats"""
     
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp20No60 Read_State test")
@@ -231,7 +231,7 @@ class Grp20No70(base_tests.SimpleDataPlane):
     a) Send packet out message for each dataplane port.
     b) Verify the packet appears on the appropriate dataplane port"""
     
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp20No70 Packet_Out test")
@@ -299,7 +299,7 @@ class Grp20No80(base_tests.SimpleProtocol):
     a) Send OFPT_BARRIER_REQUEST
     c) Verify OFPT_BARRIER_REPLY is recieved"""
     
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp20No80 Barrier_Request_Reply test")
@@ -323,7 +323,7 @@ class Grp20No90(base_tests.SimpleDataPlane):
     a) Send a simple tcp packet to a dataplane port, without any flow-entry 
     b) Verify that a packet_in event is sent to the controller"""
     
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp20No90 Packet_In test")
@@ -360,7 +360,7 @@ class Grp20No100(base_tests.SimpleDataPlane):
     b) Verify switch also exchanges hello message -- (Poll the control plane)
     d) Verify the version field in the hello messages is openflow 1.0.0 """
     
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp20No100 Hello test")
@@ -381,7 +381,7 @@ class Grp20No110(base_tests.SimpleProtocol):
     a)  Send echo-request from the controller side, note echo body is empty here.
     b)  Verify switch responds back with echo-reply with same xid """
     
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp20No110 Echo_Without_Body test")

--- a/tests/testgroup30.py
+++ b/tests/testgroup30.py
@@ -26,7 +26,7 @@ from FuncUtils import *
 
 class Grp30No10(base_tests.SimpleDataPlane):
 
-    @wireshark_capture
+    
     def runTest(self):
         logging =  get_logger()
         logging.info("Running Grp30No10 Flood testcase")
@@ -86,7 +86,7 @@ class Grp30No20(base_tests.SimpleDataPlane):
     unset correctly.
     '''
 
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp30No20 PortMod PortDown Test")
@@ -136,7 +136,7 @@ class Grp30No40(base_tests.SimpleDataPlane):
     """Modify the behavior of physical port using Port Modification Messages
     Change OFPPC_PORT_DOWN flag  and verify change takes place by Port_Status Message"""
 
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp30No40 PortMod PortDown Test")
@@ -193,7 +193,7 @@ class Grp30No40(base_tests.SimpleDataPlane):
         
 class Grp30No80(base_tests.SimpleDataPlane):
 
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp30No80 Flood bits Test")
@@ -253,7 +253,7 @@ class Grp30No90(base_tests.SimpleDataPlane):
     Modify the behavior of physical port using Port Modification Messages
     Change OFPPC_NO_FWD flag and verify change took place with Features Request"""
 
-    @wireshark_capture
+    
     def runTest(self):
 
         logging = get_logger()
@@ -367,7 +367,7 @@ class Grp30No100(base_tests.SimpleDataPlane):
     Modify the behavior of physical port using Port Modification Messages
     Change OFPPC_NO_PACKET_IN flag and verify change took place with Features Request"""
 
-    @wireshark_capture
+    
     def runTest(self):
     
 

--- a/tests/testgroup40.py
+++ b/tests/testgroup40.py
@@ -33,7 +33,7 @@ class Grp40No10(base_tests.SimpleDataPlane):
     refuses flow entry.
     """
     
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp40No10 Overlap_Checking test")
@@ -104,7 +104,7 @@ class Grp40No20(base_tests.SimpleDataPlane):
 
     """Verify that without overlap check flag set, Grp40No20overlapping flows can be created."""  
     
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp40No20 No_Overlap_Checking test")
@@ -140,7 +140,7 @@ class Grp40No30(base_tests.SimpleDataPlane):
     
     """Verify that adding two identical flows overwrites the existing one and clears counters"""
 
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp40No30 Identical_Flows test ")
@@ -186,7 +186,7 @@ class Grp40No40(base_tests.SimpleProtocol):
     """
     verify whether the switch sends an error message when the flow table is full
     """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp40No40 testcase")
@@ -255,7 +255,7 @@ class Grp40No50(base_tests.SimpleProtocol):
     Some switches may generate an OFPT_ERROR , with type field FLOW_MOD_FAILED and code permission errors 
     (this is also acceptable)
     """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp40No50 NeverValidPort test")
@@ -302,7 +302,7 @@ class Grp40No60(base_tests.SimpleDataPlane):
     OFPBAC_BAD_OUT_PORT.
     '''
 
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp40No60 flow on non existant port test")
@@ -349,7 +349,7 @@ class Grp40No60(base_tests.SimpleDataPlane):
 class Grp40No70(base_tests.SimpleProtocol): 
 
     """Timeout values are not allowed for emergency flows"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp40No70 Emergency_Flow_Timeout test")
@@ -400,7 +400,7 @@ class Grp40No80(base_tests.SimpleDataPlane):
 
     """If a modify does not match an existing flow, the flow gets added """
     
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp40No80 Missing_Modify_Add test")
@@ -439,7 +439,7 @@ class Grp40No80(base_tests.SimpleDataPlane):
 class Grp40No90(base_tests.SimpleDataPlane):
 
     """A modified flow preserves counters"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp40No90 Modify_Action test ")
@@ -481,7 +481,7 @@ class Grp40No90(base_tests.SimpleDataPlane):
 class Grp40No100(base_tests.SimpleDataPlane):
 
     """Strict Modify Flow also changes action preserves counters"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp40No100 Strict_Modify_Action test")
@@ -530,7 +530,7 @@ class Grp40No100(base_tests.SimpleDataPlane):
 class Grp40No110(base_tests.SimpleDataPlane):
     
     """Request deletion of non-existing flow"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Delete_NonExisting_Flow Grp40No110 test begins")
@@ -568,7 +568,7 @@ class Grp40No120(base_tests.SimpleDataPlane):
     """Check deletion of flows happens and generates messages as configured.
     If Send Flow removed message Flag is set in the flow entry, the flow deletion of that respective flow should generate the flow removed message, 
     vice versa also exists """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp40No120 Send_Flow_Rem test ")
@@ -628,7 +628,7 @@ class Grp40No130(base_tests.SimpleProtocol):
 
     """Delete emergency flow and verify no message is generated.An emergency flow deletion will not generate flow-removed messages even if 
     Send Flow removed message flag was set during the emergency flow entry"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp40No130 Delete_Emer_Flow")
@@ -673,7 +673,7 @@ class Grp40No140(base_tests.SimpleDataPlane):
 
     """Delete and verify strict and non-strict behaviors
     This test compares the behavior of delete strict and non-strict"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Grp40No140 test begins")
@@ -788,7 +788,7 @@ class Grp40No190(base_tests.SimpleDataPlane):
     out_port is deleted.
     """
 
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp40No190: Delete with constraint out_port")
@@ -863,7 +863,7 @@ class Grp40No200(base_tests.SimpleDataPlane):
 
     """Add, modify flows with outport set. This field is ignored by ADD, MODIFY, and MODIFY STRICT messages."""
 
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp40No200 out_port ignored by add and modify request")
@@ -902,7 +902,7 @@ class Grp40No200(base_tests.SimpleDataPlane):
 class Grp40No220(base_tests.SimpleDataPlane):
 
     """ Verify that idle timeout is implemented"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp40No220 Idle_Timeout test ")
@@ -956,7 +956,7 @@ class Grp40No230(base_tests.SimpleDataPlane):
 
     """ Verify that hard timeout is implemented """
 
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp40No230 Hard_Timeout test ")
@@ -1004,7 +1004,7 @@ class Grp40No210(base_tests.SimpleDataPlane):
   
     """Verify that Flow removed messages for timeout is implemented."""
 
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp40No210 Flow_Timeout test ")

--- a/tests/testgroup50.py
+++ b/tests/testgroup50.py
@@ -29,7 +29,7 @@ from FuncUtils import *
 class Grp50No10(base_tests.SimpleDataPlane):
 
     """Verify for an all wildcarded flow all the injected packets would match that flow"""
-    @wireshark_capture
+    
     
     def runTest(self):
         logging = get_logger()
@@ -90,7 +90,7 @@ class Grp50No20(base_tests.SimpleDataPlane):
     
     """Verify match on single Header Field Field -- In_port """
 
-    @wireshark_capture
+    
     
     def runTest(self):
         logging = get_logger()
@@ -135,7 +135,7 @@ class Grp50No20(base_tests.SimpleDataPlane):
 class Grp50No30(base_tests.SimpleDataPlane):
     
     """Verify match on single header field -- Ethernet Src Address  """
-    @wireshark_capture
+    
     
     def runTest(self):
         logging = get_logger()
@@ -182,7 +182,7 @@ class Grp50No30(base_tests.SimpleDataPlane):
 class Grp50No40(base_tests.SimpleDataPlane):
     
     """Verify match on single Header Field Field -- Ethernet Dst Address """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp50No40 Ethernet Dst Address test")
@@ -227,7 +227,7 @@ class Grp50No40(base_tests.SimpleDataPlane):
 class Grp50No50(base_tests.SimpleDataPlane):
     
     """Verify match on single header field -- Ethernet Type """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp50No50 Ethernet Type test")
@@ -275,7 +275,7 @@ class Grp50No60(base_tests.SimpleDataPlane):
 
     """Verify match on single Header Field Field -- Vlan Id """
 
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp50No60 Match on Vlan Id  test")
@@ -322,7 +322,7 @@ class Grp50No60(base_tests.SimpleDataPlane):
 class Grp50No70(base_tests.SimpleDataPlane):
 
     """"Verify match on single Header Field Field -- Vlan Priority"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp50No70 VlanPCP test")
@@ -369,7 +369,7 @@ class Grp50No80a(base_tests.SimpleDataPlane):
 
     """"Verify match on single Header Field Field -- IP_SRC_ADDRESS 
     Generates an exact match here"""
-    @wireshark_capture
+    
     def runTest(self):
 
         logging = get_logger()
@@ -427,7 +427,7 @@ class Grp50No80b(base_tests.SimpleDataPlane):
 
     """"Verify match on single Header Field Field -- IP_SRC_ADDRESS 
     Wildcards all bits in ip_src_address here"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp50No80b widlcard Matching on IP_SRC test")
@@ -481,7 +481,7 @@ class Grp50No80c(base_tests.SimpleDataPlane):
 
     """"Verify match on single Header Field Field -- IP_SRC_ADDRESS 
     Generates an match with wildcarding certain number of bits in ip_address"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Ip_Src test")
@@ -546,7 +546,7 @@ class Grp50No90a(base_tests.SimpleDataPlane):
 
     """"Verify match on single Header Field Field -- IP_DST_ADDRESS 
     Generates an exact match here"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp50No90a IP_DST test")
@@ -604,7 +604,7 @@ class Grp50No90b(base_tests.SimpleDataPlane):
 
     """"Verify match on single Header Field Field -- IP_DST_ADDRESS 
     Generates an wildcard match here"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp50No90b Ip_Dst test")
@@ -660,7 +660,7 @@ class Grp50No90c(base_tests.SimpleDataPlane):
 
     """"Verify match on single Header Field Field -- IP_SRC_ADDRESS 
     Generates an match with wildcarding certain number of bits in ip_address"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp50No90c Ip_Src test")
@@ -724,7 +724,7 @@ class Grp50No90c(base_tests.SimpleDataPlane):
 class Grp50No100(base_tests.SimpleDataPlane):
 
     """"Verify match on single Header Field Field -- Ip Protocol"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp50No100 Ip Protocol test")
@@ -769,7 +769,7 @@ class Grp50No100(base_tests.SimpleDataPlane):
 class Grp50No110(base_tests.SimpleDataPlane):
 
     """"Verify match on single Header Field Field -- Type of service"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp50No110 Ip_Tos test")
@@ -813,7 +813,7 @@ class Grp50No110(base_tests.SimpleDataPlane):
 class Grp50No120a(base_tests.SimpleDataPlane):
     
     """Verify match on Single header field -- Tcp Source Port"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp50No120a Tcp Src Port test")
@@ -856,7 +856,7 @@ class Grp50No120a(base_tests.SimpleDataPlane):
 class Grp50No120b(base_tests.SimpleDataPlane):
     
     """Verify match on Single header field --Match on Tcp Source Port/IcmpType  """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running IcmpType test")
@@ -899,7 +899,7 @@ class Grp50No120b(base_tests.SimpleDataPlane):
 class Grp50No130a(base_tests.SimpleDataPlane):
     
     """Verify match on Single header field -- Tcp Destination Port """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp50No130 Tcp Destination Port test")
@@ -942,7 +942,7 @@ class Grp50No130a(base_tests.SimpleDataPlane):
 class Grp50No130b(base_tests.SimpleDataPlane):
     
     """Verify match on Single header field -- Tcp Destination Port/IcmpCode  """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp50No130b test")
@@ -984,7 +984,7 @@ class Grp50No130b(base_tests.SimpleDataPlane):
 class Grp50No140(base_tests.SimpleDataPlane):
     
     """Verify match on multiple header field -- Ethernet Type, Ethernet Source Address, Ethernet Destination Address """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp50No140 Multiple Header Field L2 test")
@@ -1072,7 +1072,7 @@ class Grp50No150(base_tests.SimpleDataPlane):
 
     """"Verify match on multiple Header Fielda -- L3 
     Generates a wildcard match here"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp50No150 L3 matching test")
@@ -1132,7 +1132,7 @@ class Grp50No150(base_tests.SimpleDataPlane):
 class Grp50No160(base_tests.SimpleDataPlane):
     
     """Verify match on multiple header field -- Tcp Source Port, Tcp Destination Port  """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp50No160 Multiple Header Field L4 test")
@@ -1183,7 +1183,7 @@ class Grp50No160(base_tests.SimpleDataPlane):
 class Grp50No170(base_tests.SimpleDataPlane):
     
     """Verify match on All header fields -- Exact Match  """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp50No170 Exact Match test")
@@ -1225,7 +1225,7 @@ class Grp50No170(base_tests.SimpleDataPlane):
 class Grp50No180(base_tests.SimpleDataPlane):
     
     """Verify that Exact Match has highest priority """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp50No180a Exact Match High Priority test")
@@ -1266,7 +1266,7 @@ class Grp50No180(base_tests.SimpleDataPlane):
 class Grp50No190(base_tests.SimpleDataPlane):
     
     """Verify that Wildcard Match with highest priority overrides the low priority WildcardMatch """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp50No190 Wildcard Match High Priority test")
@@ -1301,7 +1301,7 @@ class Grp50No190(base_tests.SimpleDataPlane):
 
 class Grp50No210(base_tests.SimpleDataPlane):
     """ Verify that the switch matches on the ether type=0x0806 and also the IP source address"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp50No210 match on ether type and IP source address test")
@@ -1340,7 +1340,7 @@ class Grp50No210(base_tests.SimpleDataPlane):
 
 class Grp50No220(base_tests.SimpleDataPlane):
     """ Verify that the switch matches on the ether type=0x0806 and also the IP destination address"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp50No220 match on ether type and IP destination address test")

--- a/tests/testgroup60.py
+++ b/tests/testgroup60.py
@@ -38,7 +38,7 @@ class Grp60No10(base_tests.SimpleDataPlane):
 
     """Verify Packet counters per flow are
     incremented by no. of packets received for that flow"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp60No10 PktPerFlow test")
@@ -71,7 +71,7 @@ class Grp60No20(base_tests.SimpleDataPlane):
 
     """Verify Byte counters per flow are
     incremented by no. of  bytes received for that flow"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp60No20 BytPerFlow test")
@@ -112,7 +112,7 @@ class Grp60No30(base_tests.SimpleDataPlane):
     
     """Verify Duration_sec and Duration_nsec counters per flow varies in accordance with the amount of 
     time the flow was alive"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp60No30 DurationPerFlow test")
@@ -159,7 +159,7 @@ class Grp60No40(base_tests.SimpleDataPlane):
     the amount of time the flow was alive.
     '''
 
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp60No40 Duration (nsecs).")
@@ -208,7 +208,7 @@ class Grp60No50(base_tests.SimpleDataPlane):
 
     """Verify that rx_packets counter in the Port_Stats reply
         increments when packets are received on a port"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp60No50 RxPktPerPort test")
@@ -245,7 +245,7 @@ class Grp60No50(base_tests.SimpleDataPlane):
 class Grp60No60(base_tests.SimpleDataPlane):
 
     """Verify that tx_packets counter in the Port_Stats reply , increments when packets are transmitted by a port"""
-    @wireshark_capture  
+      
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp60No60 TxPktPerPort test")
@@ -283,7 +283,7 @@ class Grp60No60(base_tests.SimpleDataPlane):
 class Grp60No70(base_tests.SimpleDataPlane):
 
     """Verify that recieved bytes counter in the Port_Stats reply , increments in accordance with the bytes recieved on a port"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp60No70 RxBytPerPort test")
@@ -324,7 +324,7 @@ class Grp60No70(base_tests.SimpleDataPlane):
 class Grp60No80(base_tests.SimpleDataPlane):
 
     """Verify that trasnsmitted bytes counter in the Port_Stats reply , increments in accordance with the bytes trasmitted by a port"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp60No80 TxBytPerPort test")
@@ -364,7 +364,7 @@ class Grp60No80(base_tests.SimpleDataPlane):
 class Grp60No90(base_tests.SimpleDataPlane):
 
     """Verify that rx_dropped counters in the Port_Stats reply increments in accordance with the packets dropped by RX"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp60No90 Rx_Drops test")
@@ -390,7 +390,7 @@ class Grp60No90(base_tests.SimpleDataPlane):
 class Grp60No100(base_tests.SimpleDataPlane):
 
     """Verify that tx_dropped counters in the Port_Stats reply increments in accordance with the packets dropped by TX"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp60No100 Tx_Drops test")
@@ -418,7 +418,7 @@ class Grp60No110(base_tests.SimpleDataPlane):
     """Verify that rx_errors counters in the Port_Stats reply increments in accordance with number of recieved error  
           This is a super-set of more specific receive errors and should be greater than or equal to the sum of all
                   rx_*_err values"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp60No110 Rx_Errors test")
@@ -444,7 +444,7 @@ class Grp60No110(base_tests.SimpleDataPlane):
 class Grp60No120(base_tests.SimpleDataPlane):
 
     """Verify that Tx_errors counters in the Port_Stats reply increments in accordance with number of trasmit error"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp60No120 Tx_Errors test")
@@ -470,7 +470,7 @@ class Grp60No120(base_tests.SimpleDataPlane):
 class Grp60No130(base_tests.SimpleDataPlane):
 
     """Verify that rx_frm_err counters in the Port_Stats reply increments in accordance with the number of frame alignment errors"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp60No130 Rx_Frame_Err test")
@@ -497,7 +497,7 @@ class Grp60No130(base_tests.SimpleDataPlane):
 class Grp60No140(base_tests.SimpleDataPlane):
 
     """Verify that rx_over_err counters in the Port_Stats reply increments in accordance with the number of with RX overrun"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp60No140 Rx_O_Err test")
@@ -523,7 +523,7 @@ class Grp60No140(base_tests.SimpleDataPlane):
 class Grp60No150(base_tests.SimpleDataPlane):
 
     """Verify that rx_crc_err counters in the Port_Stats reply increments in accordance with the number of crc errors"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp60No150 crc_error test")
@@ -549,7 +549,7 @@ class Grp60No150(base_tests.SimpleDataPlane):
 class Grp60No160(base_tests.SimpleDataPlane):
 
     """Verify that collisons counters in the Port_Stats reply increments in accordance with the collisions encountered by the switch """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp60No160 Collisions test")
@@ -575,7 +575,7 @@ class Grp60No160(base_tests.SimpleDataPlane):
 class Grp60No170(base_tests.SimpleDataPlane):
 
     """Verify that tx_packets in the queue_stats reply increments in accordance with the number of transmitted packets"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp60No170 TxPktPerQueue test")
@@ -619,7 +619,7 @@ class Grp60No170(base_tests.SimpleDataPlane):
 class Grp60No180(base_tests.SimpleDataPlane):
 
     """Verify that tx_bytes in the queue_stats reply increments in accordance with the number of transmitted bytes"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp60No180 TxBytPerQueue test")
@@ -665,7 +665,7 @@ class Grp60No180(base_tests.SimpleDataPlane):
 class Grp60No190(base_tests.SimpleDataPlane):
 
     """Verify that tx_errors in the queue_stats reply increments in accordance with the number of packets dropped due to overrun """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp60No190 TxErrorPerQueue test")
@@ -693,7 +693,7 @@ class Grp60No190(base_tests.SimpleDataPlane):
 class Grp60No200(base_tests.SimpleDataPlane):
 
     """Verify that active_count counter in the Table_Stats reply , increments in accordance with the flows inserted in a table"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp60No200 Active Counter test")
@@ -721,7 +721,7 @@ class Grp60No210(base_tests.SimpleDataPlane):
     
     """Verify that lookup_count and matched_count counter in the Table_Stats reply 
         increments in accordance with the packets looked up and matched with the flows in the table"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp60No210 LookupMatchedCount test")

--- a/tests/testgroup70.py
+++ b/tests/testgroup70.py
@@ -29,7 +29,7 @@ class Grp70No10(base_tests.SimpleDataPlane):
 
     """NoActionDrop : no action added to flow , drops the packet."""
 
-    @wireshark_capture
+    
     def runTest(self):
 
         logging = get_logger()
@@ -86,7 +86,7 @@ class Grp70No20(base_tests.SimpleDataPlane):
     """Announcement : Get all supported actions by the switch.
     Send OFPT_FEATURES_REQUEST to get features supported by sw."""
 
-    @wireshark_capture
+    
     def runTest(self):
 
         logging = get_logger()
@@ -135,7 +135,7 @@ class Grp70No30(base_tests.SimpleDataPlane):
     """ForwardAll : Packet is sent to all dataplane ports
     except ingress port when output action.port = OFPP_ALL"""
 
-    @wireshark_capture
+    
     def runTest(self):
 
         logging = get_logger()
@@ -192,7 +192,7 @@ class Grp70No40(base_tests.SimpleDataPlane):
     """ForwardController : Packet is sent to controller 
     output.port = OFPP_CONTROLLER"""
 
-    @wireshark_capture
+    
     def runTest(self):
         
         logging = get_logger()
@@ -250,7 +250,7 @@ class Grp70No50(base_tests.SimpleDataPlane):
     """ForwardLocal : Packet is sent to  OFPP_LOCAL port . 
         TBD : To verify packet recieved in the local networking stack of switch"""
 
-    @wireshark_capture
+    
     def runTest(self):
 
         logging = get_logger()
@@ -304,7 +304,7 @@ class Grp70No60(base_tests.SimpleDataPlane):
         If the output action.port in the packetout message = OFP.TABLE , then 
         the packet implements the action specified in the matching flow of the FLOW-TABLE"""
 
-    @wireshark_capture
+    
     def runTest(self):
 
         logging = get_logger()
@@ -346,7 +346,7 @@ class Grp70No70(base_tests.SimpleDataPlane):
     """ ForwardInPort : Packet sent to virtual port IN_PORT
     If the output.port = OFPP.INPORT then the packet is sent to the input port itself"""
 
-    @wireshark_capture
+    
     def runTest(self):
 
         logging = get_logger()
@@ -405,7 +405,7 @@ class Grp70No90(base_tests.SimpleDataPlane):
     TBD : Verification---Incase of STP being implemented, flood the packet along the minimum spanning tree,
              not including the incoming interface. """
     
-    @wireshark_capture
+    
     def runTest(self):
 
         logging = get_logger()
@@ -459,7 +459,7 @@ class Grp70No110 (base_tests.SimpleDataPlane):
     """
     Cannot test the correctness of the testcase without vendor specs
     """
-    @wireshark_capture
+    
     def runTest(self):
         logging=get_logger()
         logging.info("Running Grp70No110 forward Enqueue test")
@@ -496,7 +496,7 @@ class Grp70No100(base_tests.SimpleDataPlane):
     ports.
     """
     
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp70No100 Forward: Multiple Ports")
@@ -541,7 +541,7 @@ class Grp70No120(base_tests.SimpleDataPlane):
     
     """AddVlanTag : Adds VLAN Tag to untagged packet."""
 
-    @wireshark_capture
+    
     def runTest(self):
 
         logging = get_logger()
@@ -584,7 +584,7 @@ class Grp70No130(base_tests.SimpleDataPlane):
 
     """ModifyVlanTag : Modifies VLAN Tag to tagged packet."""
     
-    @wireshark_capture
+    
     def runTest(self):
 
         logging = get_logger()
@@ -624,7 +624,7 @@ class Grp70No140(base_tests.SimpleDataPlane):
    
     """AddVlanPrioUntaggedPkt : Add VLAN priority to untagged packet."""
     
-    @wireshark_capture
+    
     def runTest(self):
 
         logging = get_logger()
@@ -666,7 +666,7 @@ class Grp70No150(base_tests.SimpleDataPlane):
     
     """ModifyVlanPrio : Modify VLAN priority to tagged packet."""
     
-    @wireshark_capture
+    
     def runTest(self):
         
         logging = get_logger()
@@ -707,7 +707,7 @@ class Grp70No150(base_tests.SimpleDataPlane):
 class Grp70No160(base_tests.SimpleDataPlane):
     """Strip vlan header"""
 
-    @wireshark_capture
+    
     def runTest(self):
         
         logging = get_logger()
@@ -753,7 +753,7 @@ class Grp70No170(base_tests.SimpleDataPlane):
     
     """ModifyL2Src :Modify the source MAC address"""
 
-    @wireshark_capture
+    
     def runTest(self):
 
         logging = get_logger()
@@ -790,7 +790,7 @@ class Grp70No180(base_tests.SimpleDataPlane):
     
     """ModifyL2SDSt :Modify the dest MAC address"""
 
-    @wireshark_capture
+    
     def runTest(self):
 
         logging = get_logger()
@@ -826,7 +826,7 @@ class Grp70No190(base_tests.SimpleDataPlane):
     
     """ModifyL3Src : Modify the source IP address of an IP packet """
 
-    @wireshark_capture
+    
     def runTest(self):
 
         logging = get_logger()
@@ -862,7 +862,7 @@ class Grp70No200(base_tests.SimpleDataPlane):
     
     """ModifyL3Dst :Modify the dest IP address of an IP packet"""
     
-    @wireshark_capture
+    
     def runTest(self):
 
         logging = get_logger()
@@ -898,7 +898,7 @@ class Grp70No210(base_tests.SimpleDataPlane):
     
     """ModifyTOS :Modify the IP type of service of an IP packet"""
     
-    @wireshark_capture
+    
     def runTest(self):
 
         logging = get_logger()
@@ -935,7 +935,7 @@ class Grp70No220(base_tests.SimpleDataPlane):
     
     """ModifyL4Src : Modify the source TCP port of a TCP packet"""
     
-    @wireshark_capture
+    
     def runTest(self):
 
         logging = get_logger()
@@ -971,7 +971,7 @@ class Grp70No230(base_tests.SimpleDataPlane):
     
     """ ModifyL4Dst: Modify the dest TCP port of a TCP packet """
 
-    @wireshark_capture    
+        
     def runTest(self):
 
         logging = get_logger()

--- a/tests/testgroup80.py
+++ b/tests/testgroup80.py
@@ -53,7 +53,7 @@ class Grp80No10(base_tests.SimpleDataPlane):
         logging.info("Connected " + str(self.controller.switch_addr))
         
         
-    @wireshark_capture 
+     
     def runTest(self):
 
         logging.info("Running Grp80No10 HelloWithoutBody Test")            
@@ -100,7 +100,7 @@ class Grp80No20(base_tests.SimpleDataPlane):
         logging.info("Connected " + str(self.controller.switch_addr))
         
         
-    @wireshark_capture 
+     
     def runTest(self):
 
         logging.info("Running Grp80No20 HelloWithBody Test")            
@@ -127,7 +127,7 @@ class Grp80No30(base_tests.SimpleProtocol):
     it generates OFPT_ERROR_msg with Type field OFPET_BAD_REQUEST 
     and code field OFPBRC_BAD_VERSION
     """
-    @wireshark_capture 
+     
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp80No30 Error Msg test")
@@ -153,7 +153,7 @@ class Grp80No40(base_tests.SimpleProtocol):
     
     """Verify if OFPT_ECHO_REQUEST without body. """
 
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp80No40 EchoWithoutData test")
@@ -176,7 +176,7 @@ class Grp80No50(base_tests.SimpleProtocol):
     """Verify if OFPT_ECHO_REQUEST has data field,
     switch responds back with OFPT_ECHO_REPLY with data field copied into it. """
 
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp80No40 EchoWithData test")
@@ -207,7 +207,7 @@ class Grp80No60(base_tests.SimpleProtocol):
     Verify OFPT_FEATURES_REQUEST / REPLY dialogue.
     """
 
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp80No60: Features Request-Reply")
@@ -231,7 +231,7 @@ class Grp80No70(base_tests.SimpleProtocol):
     Verify OFPT_FEATURES_REPLY contains complete feature information.
     """
 
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp80No70 Features Reply Body test")
@@ -338,7 +338,7 @@ class Grp80No70(base_tests.SimpleProtocol):
 class Grp80No200(base_tests.SimpleProtocol):
 
     """Verify the body of OFPT_GET_CONFIG_REPLY message """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp80No200 GetConfigReply Test")
@@ -372,7 +372,7 @@ class Grp80No200(base_tests.SimpleProtocol):
 class Grp80No210(base_tests.SimpleDataPlane):
     
 
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info('Running Grp80No210 OFPC_FRAG_NORMAL')
@@ -415,7 +415,7 @@ class Grp80No210(base_tests.SimpleDataPlane):
 class Grp80No260(base_tests.SimpleProtocol):
 
     """Verify OFPT_SET_CONFIG is implemented"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp80No260 SetConfigRequest Test")
@@ -462,7 +462,7 @@ class Grp80No260(base_tests.SimpleProtocol):
 class Grp80No270(base_tests.SimpleProtocol):
 
     """Verify OFPT_SET_CONFIG is implemented"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp80No270 Test")
@@ -518,7 +518,7 @@ class Grp80No270(base_tests.SimpleProtocol):
 class Grp80No280(base_tests.SimpleProtocol):
 
     """Verify OFPT_SET_CONFIG is implemented"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp80No280 Test")
@@ -574,7 +574,7 @@ class Grp80No280(base_tests.SimpleProtocol):
 class Grp80No290(base_tests.SimpleProtocol):
 
     """Verify OFPT_SET_CONFIG is implemented"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp80No290 Test")
@@ -631,7 +631,7 @@ class Grp80No290(base_tests.SimpleProtocol):
 class Grp80No300(base_tests.SimpleProtocol):
 
     """Verify OFPT_SET_CONFIG is implemented"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp80No300 Test")

--- a/tests/testgroup80.py
+++ b/tests/testgroup80.py
@@ -30,7 +30,6 @@ class Grp80No10(base_tests.SimpleDataPlane):
 
     def setUp(self):
         start_logging(self)
-        logging = get_logger()
         #This is almost same as setUp in SimpleProtcocol except that intial hello is set to false
         self.controller = controller.Controller(
             host=config["controller_host"],
@@ -56,7 +55,7 @@ class Grp80No10(base_tests.SimpleDataPlane):
         
      
     def runTest(self):
-
+        logging = get_logger()
         logging.info("Running Grp80No10 HelloWithoutBody Test")            
         (response, pkt) = self.controller.poll(exp_msg=ofp.OFPT_HELLO,         
                                               timeout=5)
@@ -78,7 +77,6 @@ class Grp80No20(base_tests.SimpleDataPlane):
 
     def setUp(self):
         start_logging(self)
-        logging = get_logger()
         #This is almost same as setUp in SimpleProtcocol except that intial hello is set to false
         self.controller = controller.Controller(
             host=config["controller_host"],
@@ -104,7 +102,7 @@ class Grp80No20(base_tests.SimpleDataPlane):
         
      
     def runTest(self):
-
+        logging = get_logger()
         logging.info("Running Grp80No20 HelloWithBody Test")            
         (response, pkt) = self.controller.poll(exp_msg=ofp.OFPT_HELLO,         
                                               timeout=5)

--- a/tests/testgroup80.py
+++ b/tests/testgroup80.py
@@ -29,6 +29,7 @@ class Grp80No10(base_tests.SimpleDataPlane):
     """Verify switch should be able to receive OFPT_HELLO messages without body"""
 
     def setUp(self):
+        start_logging(self)
         logging = get_logger()
         #This is almost same as setUp in SimpleProtcocol except that intial hello is set to false
         self.controller = controller.Controller(
@@ -76,6 +77,7 @@ class Grp80No20(base_tests.SimpleDataPlane):
         but it should ignore the contents of the body"""
 
     def setUp(self):
+        start_logging(self)
         logging = get_logger()
         #This is almost same as setUp in SimpleProtcocol except that intial hello is set to false
         self.controller = controller.Controller(

--- a/tests/testgroup90.py
+++ b/tests/testgroup90.py
@@ -25,7 +25,7 @@ class Grp90No10(base_tests.SimpleDataPlane):
     """Verify the packet_in message body, 
     when packet_in is triggered due to a flow table miss"""
 
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp90No10 PacketInBodyMiss Test")
@@ -77,7 +77,7 @@ class Grp90No20(base_tests.SimpleDataPlane):
         verify the data sent in packet_in varies in accordance with the
         miss_send_len field set in OFPT_SET_CONFIG"""
     
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp90No20 PacketInSizeMiss Test")
@@ -125,7 +125,7 @@ class Grp90No20(base_tests.SimpleDataPlane):
 class Grp90No60(base_tests.SimpleDataPlane):
 
     """Verify the packet_in message body, when packet_in is generated due to action output to controller"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp90No60 PacketInBodyAction Test")
@@ -185,7 +185,7 @@ class Grp90No70(base_tests.SimpleDataPlane):
         verify the data sent in packet_in varies in accordance with the
         max_len field set in action_output"""
 
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp90No70 PacketInSizeAction Test")
@@ -250,7 +250,7 @@ class Grp90No110(base_tests.SimpleDataPlane):
 
     #priority = -1 #This would skip the set
     
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp90No110 PortStatusMessage Test")
@@ -292,7 +292,7 @@ class Grp90No120(base_tests.SimpleDataPlane):
     
     """ Modify the behavior of physical port using Port Modification Messages
     Change OFPPC_NO_FLOOD flag  and verify change takes place with features request """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp90No120 PortModFlood Test")
@@ -337,7 +337,7 @@ class Grp90No130(base_tests.SimpleDataPlane):
     """ 
     Modify the behavior of physical port using Port Modification Messages
     Change OFPPC_NO_FWD flag and verify change took place with Features Request"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp90No130 PortModFwd Test")
@@ -381,7 +381,7 @@ class Grp90No140(base_tests.SimpleDataPlane):
     """ 
     Modify the behavior of physical port using Port Modification Messages
     Change OFPPC_NO_PACKET_IN flag and verify change took place with Features Request"""
-    @wireshark_capture
+    
     def runTest(self):
 
         logging = get_logger()
@@ -424,7 +424,7 @@ class Grp90No140(base_tests.SimpleDataPlane):
 
 class Grp90No150(base_tests.SimpleDataPlane):
     """Verify that the Controller is able to use the Packet_out message"""
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Runnign Grp90No150 testcase")
@@ -453,7 +453,7 @@ class Grp90No150(base_tests.SimpleDataPlane):
 class Grp90No160(base_tests.SimpleDataPlane):
     
     """Verify Description Stats message body """
-    @wireshark_capture
+    
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp90No160 DescStatsGet test")
@@ -490,7 +490,7 @@ class Grp90No170(base_tests.SimpleProtocol):
 
     """Verify Queue Configuration Reply message body """
 
-    @wireshark_capture  
+      
     def runTest(self):
         logging = get_logger()
         logging.info("Running Grp90No170 QueueConfigRequest")


### PR DESCRIPTION
Now starting tshark in setUp function of basic test objects. Tests that override setUp function must include `oflog.start_logging(self)` to capture logs. tshark pids are passed to `stop_logging` which is called after `teardown` or if `setUp` exits due to an exception. `stop_logging` is registered with the testcase using `testcase.addCleanup` in `start_logging`. Fixes #102 